### PR TITLE
Add model dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,5 @@ Run `npm run dev` and open the app in your browser. The home page lists all exis
 
 To chat with an assistant the frontend now posts messages to `/api/assistants/<uuid>/chat/`. The backend returns the assistant's reply which is displayed in the chat window.
 
+When creating a new assistant you can select a model from a dropdown menu. The list of options is fetched directly from the OpenAI API using your `VITE_OPENAI_API_KEY` and the chosen model is sent along with the create request.
+

--- a/src/pages/CreateAssistantPage.tsx
+++ b/src/pages/CreateAssistantPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 export default function CreateAssistantPage() {
@@ -6,8 +6,30 @@ export default function CreateAssistantPage() {
   const [description, setDescription] = useState('');
   const [instructions, setInstructions] = useState('');
   const [tools, setTools] = useState('');
+  const [model, setModel] = useState('');
+  const [models, setModels] = useState<string[]>([]);
   const [status, setStatus] = useState<string | null>(null);
   const navigate = useNavigate();
+
+  const fetchModels = async () => {
+    try {
+      const key = import.meta.env.VITE_OPENAI_API_KEY;
+      const res = await fetch('https://api.openai.com/v1/models', {
+        headers: { Authorization: `Bearer ${key}` },
+      });
+      if (res.ok) {
+        const data = await res.json();
+        const list = Array.isArray(data.data) ? data.data : data;
+        setModels(list.map((m: any) => m.id ?? m));
+      }
+    } catch {
+      // ignore errors
+    }
+  };
+
+  useEffect(() => {
+    void fetchModels();
+  }, []);
 
   const createAssistant = async () => {
     try {
@@ -15,6 +37,7 @@ export default function CreateAssistantPage() {
         name,
         description,
         instructions,
+        model,
         tools: tools
           .split(',')
           .map((t) => t.trim())
@@ -65,6 +88,18 @@ export default function CreateAssistantPage() {
           onChange={(e) => setInstructions(e.target.value)}
           placeholder="Instructions"
         />
+        <select
+          className="border p-2 w-full"
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+        >
+          <option value="">Select Model</option>
+          {models.map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
         <input
           className="border p-2 w-full"
           type="text"


### PR DESCRIPTION
## Summary
- load list of models from https://api.openai.com/v1/models using `VITE_OPENAI_API_KEY`
- allow selecting a model when creating an assistant
- document model selection

## Testing
- `npm install` *(fails: Exit handler never called)*
- `npm run lint` *(fails: Cannot find package '/workspace/assistant_frontend/node_modules/globals/index.js' imported from eslint.config.js)*
