### PR TITLE
Limit models drop-down

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,6 @@ Run `npm run dev` and open the app in your browser. The home page lists all exis
 To chat with an assistant the frontend now posts messages to `/api/assistants/<uuid>/chat/`. The backend returns the assistant's reply which is displayed in the chat window.
 
 
-When creating a new assistant you can select a model from a dropdown menu. The list of options is fetched directly from the OpenAI API using your `VITE_OPENAI_API_KEY` and the chosen model is sent along with the create request.
+When creating a new assistant you can select a model from a dropdown menu. The list now includes a fixed set of options (`gpt-4`, `gpt-4o`, `o1-mini`, `o3-mini`) and the chosen model is sent along with the create request.
 
 

--- a/src/pages/CreateAssistantPage.tsx
+++ b/src/pages/CreateAssistantPage.tsx
@@ -1,5 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+
+const MODEL_OPTIONS = ['gpt-4', 'gpt-4o', 'o1-mini', 'o3-mini'];
 
 export default function CreateAssistantPage() {
   const [name, setName] = useState('');
@@ -7,29 +9,8 @@ export default function CreateAssistantPage() {
   const [instructions, setInstructions] = useState('');
   const [tools, setTools] = useState('');
   const [model, setModel] = useState('');
-  const [models, setModels] = useState<string[]>([]);
   const [status, setStatus] = useState<string | null>(null);
   const navigate = useNavigate();
-
-  const fetchModels = async () => {
-    try {
-      const key = import.meta.env.VITE_OPENAI_API_KEY;
-      const res = await fetch('https://api.openai.com/v1/models', {
-        headers: { Authorization: `Bearer ${key}` },
-      });
-      if (res.ok) {
-        const data = await res.json();
-        const list = Array.isArray(data.data) ? data.data : data;
-        setModels(list.map((m: any) => m.id ?? m));
-      }
-    } catch {
-      // ignore errors
-    }
-  };
-
-  useEffect(() => {
-    void fetchModels();
-  }, []);
 
   const createAssistant = async () => {
     try {
@@ -94,7 +75,7 @@ export default function CreateAssistantPage() {
           onChange={(e) => setModel(e.target.value)}
         >
           <option value="">Select Model</option>
-          {models.map((m) => (
+          {MODEL_OPTIONS.map((m) => (
             <option key={m} value={m}>
               {m}
             </option>

--- a/src/pages/EditAssistantPage.tsx
+++ b/src/pages/EditAssistantPage.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
+const MODEL_OPTIONS = ['gpt-4', 'gpt-4o', 'o1-mini', 'o3-mini'];
+
 export default function EditAssistantPage() {
   const { id } = useParams<{ id: string }>();
   const [name, setName] = useState('');
@@ -8,25 +10,8 @@ export default function EditAssistantPage() {
   const [instructions, setInstructions] = useState('');
   const [tools, setTools] = useState('');
   const [model, setModel] = useState('');
-  const [models, setModels] = useState<string[]>([]);
   const [status, setStatus] = useState<string | null>(null);
   const navigate = useNavigate();
-
-  const fetchModels = async () => {
-    try {
-      const key = import.meta.env.VITE_OPENAI_API_KEY;
-      const res = await fetch('https://api.openai.com/v1/models', {
-        headers: { Authorization: `Bearer ${key}` },
-      });
-      if (res.ok) {
-        const data = await res.json();
-        const list = Array.isArray(data.data) ? data.data : data;
-        setModels(list.map((m: any) => m.id ?? m));
-      }
-    } catch {
-      // ignore errors
-    }
-  };
 
   const fetchAssistant = async () => {
     try {
@@ -48,7 +33,6 @@ export default function EditAssistantPage() {
 
   useEffect(() => {
     void fetchAssistant();
-    void fetchModels();
   }, [id]);
 
   const updateAssistant = async () => {
@@ -114,7 +98,7 @@ export default function EditAssistantPage() {
           onChange={(e) => setModel(e.target.value)}
         >
           <option value="">Select Model</option>
-          {models.map((m) => (
+          {MODEL_OPTIONS.map((m) => (
             <option key={m} value={m}>
               {m}
             </option>


### PR DESCRIPTION
## Summary
- simplify assistant creation/edit forms by dropping model fetching
- allow choosing from `gpt-4`, `gpt-4o`, `o1-mini` and `o3-mini`
- document new fixed model list in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*