### PR TITLE
Disable button during assistant update

### DIFF
--- a/src/pages/EditAssistantPage.tsx
+++ b/src/pages/EditAssistantPage.tsx
@@ -10,6 +10,7 @@ export default function EditAssistantPage() {
   const [model, setModel] = useState('');
   const [models, setModels] = useState<string[]>([]);
   const [status, setStatus] = useState<string | null>(null);
+  const [waiting, setWaiting] = useState(false);
   const navigate = useNavigate();
 
   const fetchModels = async () => {
@@ -52,6 +53,11 @@ export default function EditAssistantPage() {
   }, [id]);
 
   const updateAssistant = async () => {
+    if (waiting) {
+      return;
+    }
+    setStatus(null);
+    setWaiting(true);
     try {
       const payload = {
         name,
@@ -72,10 +78,11 @@ export default function EditAssistantPage() {
         const data = await res.text();
         throw new Error(data || res.statusText);
       }
-      setStatus('Assistant updated successfully');
       navigate('/');
     } catch (err: any) {
       setStatus(`Error: ${err.message}`);
+    } finally {
+      setWaiting(false);
     }
   };
 
@@ -128,7 +135,8 @@ export default function EditAssistantPage() {
           placeholder="Tools (comma separated)"
         />
         <button
-          className="bg-blue-500 text-white px-4 py-2 rounded"
+          className="bg-blue-500 text-white px-4 py-2 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+          disabled={waiting}
           onClick={updateAssistant}
         >
           Update


### PR DESCRIPTION
## Summary
- prevent multiple submissions in Edit Assistant page
- show error message if update fails
- return to home once the assistant is saved

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script "test")*