### PR TITLE
Enable basic markdown rendering

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -1,0 +1,94 @@
+import React, { useMemo } from 'react';
+
+interface MarkdownProps {
+  text: string;
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function processInline(text: string): string {
+  let result = escapeHtml(text);
+  result = result.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+  result = result.replace(/\*(.+?)\*/g, '<em>$1</em>');
+  return result;
+}
+
+export default function Markdown({ text }: MarkdownProps) {
+  const html = useMemo(() => {
+    const lines = text.split(/\r?\n/);
+    const out: string[] = [];
+    let inOl = false;
+    let inUl = false;
+    let paragraph: string[] = [];
+
+    const closeLists = () => {
+      if (inOl) {
+        out.push('</ol>');
+        inOl = false;
+      }
+      if (inUl) {
+        out.push('</ul>');
+        inUl = false;
+      }
+    };
+
+    const flushParagraph = () => {
+      if (paragraph.length > 0) {
+        out.push('<p>' + processInline(paragraph.join(' ')) + '</p>');
+        paragraph = [];
+      }
+    };
+
+    for (const rawLine of lines) {
+      const line = rawLine.replace(/\s+$/, '');
+      if (/^\d+\.\s+/.test(line)) {
+        flushParagraph();
+        if (!inOl) {
+          closeLists();
+          out.push('<ol>');
+          inOl = true;
+        }
+        out.push('<li>' + processInline(line.replace(/^\d+\.\s+/, '')) + '</li>');
+      } else if (/^[-*]\s+/.test(line)) {
+        flushParagraph();
+        if (!inUl) {
+          closeLists();
+          out.push('<ul>');
+          inUl = true;
+        }
+        out.push('<li>' + processInline(line.replace(/^[-*]\s+/, '')) + '</li>');
+      } else if (/^###\s+/.test(line)) {
+        flushParagraph();
+        closeLists();
+        out.push('<h3>' + processInline(line.slice(4)) + '</h3>');
+      } else if (/^##\s+/.test(line)) {
+        flushParagraph();
+        closeLists();
+        out.push('<h2>' + processInline(line.slice(3)) + '</h2>');
+      } else if (/^#\s+/.test(line)) {
+        flushParagraph();
+        closeLists();
+        out.push('<h1>' + processInline(line.slice(2)) + '</h1>');
+      } else if (line.trim() === '') {
+        flushParagraph();
+        closeLists();
+      } else {
+        paragraph.push(line);
+      }
+    }
+
+    flushParagraph();
+    closeLists();
+
+    return out.join('');
+  }, [text]);
+
+  return <div className="space-y-2" dangerouslySetInnerHTML={{ __html: html }} />;
+}

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import type { Assistant } from './HomePage';
+import Markdown from '../components/Markdown';
 
 interface Message {
   id: string;
@@ -91,11 +92,11 @@ export default function ChatPage() {
       <h1 className="text-xl font-bold">
         Chat with {assistant ? assistant.name : id}
       </h1>
-      <div className="border p-2 h-64 overflow-y-auto space-y-2">
+      <div className="border p-2 h-64 overflow-y-auto space-y-4">
         {messages.map((msg) => (
           <div key={msg.id}>
-            <span className="font-semibold">{msg.role}: </span>
-            {msg.content}
+            <div className="font-semibold mb-1">{msg.role}:</div>
+            <Markdown text={msg.content} />
           </div>
         ))}
         {waiting && (


### PR DESCRIPTION
## Summary
- add a minimal Markdown renderer component
- render chat messages with Markdown formatting

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npm run build` *(fails: cannot find module 'react')*