### PR TITLE
Remove o1-mini from model options

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,6 @@ Run `npm run dev` and open the app in your browser. The home page lists all exis
 To chat with an assistant the frontend now posts messages to `/api/assistants/<uuid>/chat/`. The backend returns the assistant's reply which is displayed in the chat window.
 
 
-When creating a new assistant you can select a model from a dropdown menu. The list now includes a fixed set of options (`gpt-4`, `gpt-4o`, `o1-mini`, `o3-mini`) and the chosen model is sent along with the create request.
+When creating a new assistant you can select a model from a dropdown menu. The list now includes a fixed set of options (`gpt-4`, `gpt-4o`, `o3-mini`) and the chosen model is sent along with the create request.
 
 

--- a/src/pages/CreateAssistantPage.tsx
+++ b/src/pages/CreateAssistantPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-const MODEL_OPTIONS = ['gpt-4', 'gpt-4o', 'o1-mini', 'o3-mini'];
+const MODEL_OPTIONS = ['gpt-4', 'gpt-4o', 'o3-mini'];
 
 export default function CreateAssistantPage() {
   const [name, setName] = useState('');

--- a/src/pages/EditAssistantPage.tsx
+++ b/src/pages/EditAssistantPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
-const MODEL_OPTIONS = ['gpt-4', 'gpt-4o', 'o1-mini', 'o3-mini'];
+const MODEL_OPTIONS = ['gpt-4', 'gpt-4o', 'o3-mini'];
 
 export default function EditAssistantPage() {
   const { id } = useParams<{ id: string }>();


### PR DESCRIPTION
## Summary
- remove o1-mini from allowed models

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*