### PR TITLE
Enable file upload on assistant creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,6 @@ To chat with an assistant the frontend now posts messages to `/api/assistants/<u
 
 When creating a new assistant you can select a model from a dropdown menu. The list now includes a fixed set of options (`gpt-4`, `gpt-4o`, `o3-mini`) and the chosen model is sent along with the create request.
 
+File uploads are also supported during assistant creation. Select one or more files in the form and they will be uploaded using `multipart/form-data` when the request is sent to `/api/assistants/`.
+
 

--- a/src/pages/CreateAssistantPage.tsx
+++ b/src/pages/CreateAssistantPage.tsx
@@ -9,25 +9,27 @@ export default function CreateAssistantPage() {
   const [instructions, setInstructions] = useState('');
   const [tools, setTools] = useState('');
   const [model, setModel] = useState('');
+  const [files, setFiles] = useState<File[]>([]);
   const [status, setStatus] = useState<string | null>(null);
   const navigate = useNavigate();
 
   const createAssistant = async () => {
     try {
-      const payload = {
-        name,
-        description,
-        instructions,
-        model,
-        tools: tools
-          .split(',')
-          .map((t) => t.trim())
-          .filter((t) => t.length > 0),
-      };
+      const form = new FormData();
+      form.append('name', name);
+      if (description.trim() !== '') form.append('description', description);
+      if (instructions.trim() !== '') form.append('instructions', instructions);
+      if (model) form.append('model', model);
+      tools
+        .split(',')
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0)
+        .forEach((t) => form.append('tools', t));
+      files.forEach((f) => form.append('files', f));
+
       const res = await fetch('/api/assistants/', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
+        body: form,
       });
       if (!res.ok) {
         const data = await res.text();
@@ -87,6 +89,12 @@ export default function CreateAssistantPage() {
           value={tools}
           onChange={(e) => setTools(e.target.value)}
           placeholder="Tools (comma separated)"
+        />
+        <input
+          className="border p-2 w-full rounded-lg focus:outline focus:outline-2 focus:outline-accent"
+          type="file"
+          multiple
+          onChange={(e) => setFiles(Array.from(e.target.files ?? []))}
         />
         <button
           className="bg-accent text-white px-4 py-2 rounded-lg"


### PR DESCRIPTION
## Summary
- support file uploads when creating an assistant
- mention the new upload feature in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*