### PR TITLE
Fix file search detection on edit page

### DIFF
--- a/src/pages/EditAssistantPage.tsx
+++ b/src/pages/EditAssistantPage.tsx
@@ -27,7 +27,13 @@ export default function EditAssistantPage() {
         setInstructions(data.instructions || '');
         setModel(data.model || '');
         if (Array.isArray(data.tools)) {
-          setFileSearch(data.tools.includes('file_search'));
+          setFileSearch(
+            data.tools.some((t: any) =>
+              typeof t === 'string'
+                ? t === 'file_search'
+                : t && t.type === 'file_search'
+            )
+          );
         }
         if (Array.isArray(data.files)) {
           setExistingFiles(data.files);


### PR DESCRIPTION
## Summary
- handle string/object styles in `tools` array when editing an assistant

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*