### PR TITLE
Fix tools form value when clearing file search

### DIFF
--- a/src/pages/EditAssistantPage.tsx
+++ b/src/pages/EditAssistantPage.tsx
@@ -63,10 +63,8 @@ export default function EditAssistantPage() {
       if (fileSearch) {
         form.append('tools', 'file_search');
       } else {
-
-        // send an explicit empty list so the backend clears existing tools
-        form.append('tools', '[]');
-
+        // clear existing tools by sending an empty value
+        form.append('tools', '');
       }
       newFiles.forEach((f) => form.append('files', f));
       removeFiles.forEach((id) => form.append('remove_files', id));


### PR DESCRIPTION
## Summary
- when editing an assistant, send an empty string instead of `[]` to clear the tools setting

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*