### PR TITLE
Handle missing filenames from vector store API

### DIFF
--- a/src/pages/EditAssistantPage.tsx
+++ b/src/pages/EditAssistantPage.tsx
@@ -54,7 +54,19 @@ export default function EditAssistantPage() {
         const res = await fetch(`/api/assistants/${id}/vector-store/files/`);
         if (res.ok) {
           const data = await res.json();
-          setVectorFiles(data);
+          const items = Array.isArray(data)
+            ? data.map((f: any) => ({
+                ...f,
+                filename:
+                  f.filename ??
+                  f.name ??
+                  f.file_name ??
+                  f.file_id ??
+                  '',
+                id: f.id ?? f.file_id,
+              }))
+            : [];
+          setVectorFiles(items);
         } else if (res.status === 404) {
           const msg = await res.text();
           setVectorStatus(msg || 'No vector store for this assistant.');

--- a/src/pages/VectorStoreFilesPage.tsx
+++ b/src/pages/VectorStoreFilesPage.tsx
@@ -20,7 +20,20 @@ export default function VectorStoreFilesPage() {
         const res = await fetch(`/api/assistants/${id}/vector-store/files/`);
         if (res.ok) {
           const data = await res.json();
-          setFiles(data);
+          const items = Array.isArray(data)
+            ? data.map((f: any) => ({
+                ...f,
+                // Support older API responses that may not include a filename
+                filename:
+                  f.filename ??
+                  f.name ??
+                  f.file_name ??
+                  f.file_id ??
+                  '',
+                id: f.id ?? f.file_id,
+              }))
+            : [];
+          setFiles(items);
         } else if (res.status === 404) {
           const msg = await res.text();
           setStatus(msg || 'No vector store for this assistant.');


### PR DESCRIPTION
## Summary
- map vector store file responses to ensure `filename` and `id` fields are present even if backend response doesn't include them

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*