### PR TITLE
Update file inputs to single file with up to 20 selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ To chat with an assistant the frontend now posts messages to `/api/assistants/<u
 
 When creating a new assistant you can select a model from a dropdown menu. The list now includes a fixed set of options (`gpt-4`, `gpt-4o`, `o3-mini`) and the chosen model is sent along with the create request.
 
-File uploads are also supported during assistant creation. Select one or more files in the form and they will be uploaded using `multipart/form-data` when the request is sent to `/api/assistants/`.
+File uploads are also supported during assistant creation. You may add files individually (up to 20 in total) and they will be uploaded using `multipart/form-data` when the request is sent to `/api/assistants/`.
 
-Existing assistants can be edited in the UI. When updating you may upload additional files or select existing ones to remove. The form submits a `PATCH` request to `/api/assistants/<uuid>/` including any new `files` and a `remove_files` list containing the file IDs to delete.
+Existing assistants can be edited in the UI. When updating you may add new files one at a time (again up to 20) or select existing ones to remove. The form submits a `PATCH` request to `/api/assistants/<uuid>/` including any new `files` and a `remove_files` list containing the file IDs to delete.
 
 

--- a/src/pages/CreateAssistantPage.tsx
+++ b/src/pages/CreateAssistantPage.tsx
@@ -9,7 +9,7 @@ export default function CreateAssistantPage() {
   const [instructions, setInstructions] = useState('');
   const [fileSearch, setFileSearch] = useState(false);
   const [model, setModel] = useState('');
-  const [files, setFiles] = useState<File[]>([]);
+  const [files, setFiles] = useState<(File | null)[]>([null]);
   const [status, setStatus] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
   const navigate = useNavigate();
@@ -28,7 +28,11 @@ export default function CreateAssistantPage() {
       if (fileSearch) {
         form.append('tools', 'file_search');
       }
-      files.forEach((f) => form.append('files', f));
+      files.forEach((f) => {
+        if (f) {
+          form.append('files', f);
+        }
+      });
 
       const res = await fetch('/api/assistants/', {
         method: 'POST',
@@ -96,12 +100,29 @@ export default function CreateAssistantPage() {
           />
           <span>Enable file search</span>
         </label>
-        <input
-          className="border p-2 w-full rounded-lg focus:outline focus:outline-2 focus:outline-accent"
-          type="file"
-          multiple
-          onChange={(e) => setFiles(Array.from(e.target.files ?? []))}
-        />
+        {files.map((_, i) => (
+          <input
+            key={i}
+            className="border p-2 w-full rounded-lg focus:outline focus:outline-2 focus:outline-accent"
+            type="file"
+            onChange={(e) =>
+              setFiles((cur) => {
+                const next = [...cur];
+                next[i] = e.target.files?.[0] ?? null;
+                return next;
+              })
+            }
+          />
+        ))}
+        {files.length < 20 && (
+          <button
+            type="button"
+            className="bg-gray-200 text-gray-700 px-2 py-1 rounded"
+            onClick={() => setFiles((cur) => [...cur, null])}
+          >
+            Add File
+          </button>
+        )}
         <button
           className={`px-4 py-2 rounded-lg text-white ${creating ? 'bg-grey60' : 'bg-accent'} disabled:cursor-not-allowed`}
           disabled={creating}

--- a/src/pages/EditAssistantPage.tsx
+++ b/src/pages/EditAssistantPage.tsx
@@ -13,7 +13,7 @@ export default function EditAssistantPage() {
   const [status, setStatus] = useState<string | null>(null);
   const [waiting, setWaiting] = useState(false);
   const [existingFiles, setExistingFiles] = useState<{ id: string; name: string }[]>([]);
-  const [newFiles, setNewFiles] = useState<File[]>([]);
+  const [newFiles, setNewFiles] = useState<(File | null)[]>([]);
   const [removeFiles, setRemoveFiles] = useState<Set<string>>(new Set());
   const [vectorFiles, setVectorFiles] = useState<{ id: string; filename: string }[]>([]);
   const [vectorStatus, setVectorStatus] = useState<string | null>(null);
@@ -100,7 +100,11 @@ export default function EditAssistantPage() {
         // clear existing tools by sending an empty value
         form.append('tools', '[]');
       }
-      newFiles.forEach((f) => form.append('files', f));
+      newFiles.forEach((f) => {
+        if (f) {
+          form.append('files', f);
+        }
+      });
       removeFiles.forEach((id) => form.append('remove_files', id));
 
       const res = await fetch(`/api/assistants/${id}/`, {
@@ -204,12 +208,29 @@ export default function EditAssistantPage() {
             ))}
           </div>
         )}
-        <input
-          className="border p-2 w-full rounded-lg focus:outline focus:outline-2 focus:outline-accent"
-          type="file"
-          multiple
-          onChange={(e) => setNewFiles(Array.from(e.target.files ?? []))}
-        />
+        {newFiles.map((_, i) => (
+          <input
+            key={i}
+            className="border p-2 w-full rounded-lg focus:outline focus:outline-2 focus:outline-accent"
+            type="file"
+            onChange={(e) =>
+              setNewFiles((cur) => {
+                const next = [...cur];
+                next[i] = e.target.files?.[0] ?? null;
+                return next;
+              })
+            }
+          />
+        ))}
+        {newFiles.length < 20 && (
+          <button
+            type="button"
+            className="bg-gray-200 text-gray-700 px-2 py-1 rounded"
+            onClick={() => setNewFiles((cur) => [...cur, null])}
+          >
+            Add File
+          </button>
+        )}
         <button
           className="bg-accent text-white px-4 py-2 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
           disabled={waiting}


### PR DESCRIPTION
## Summary
- allow selecting files one at a time when creating or editing an assistant
- permit adding up to 20 file inputs
- update README to document new behaviour

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*