### PR TITLE
Allow removing added file inputs

### DIFF
--- a/src/pages/CreateAssistantPage.tsx
+++ b/src/pages/CreateAssistantPage.tsx
@@ -101,18 +101,30 @@ export default function CreateAssistantPage() {
           <span>Enable file search</span>
         </label>
         {files.map((_, i) => (
-          <input
-            key={i}
-            className="border p-2 w-full rounded-lg focus:outline focus:outline-2 focus:outline-accent"
-            type="file"
-            onChange={(e) =>
-              setFiles((cur) => {
-                const next = [...cur];
-                next[i] = e.target.files?.[0] ?? null;
-                return next;
-              })
-            }
-          />
+          <div key={i} className="flex items-center space-x-2">
+            <input
+              className="border p-2 flex-1 rounded-lg focus:outline focus:outline-2 focus:outline-accent"
+              type="file"
+              onChange={(e) =>
+                setFiles((cur) => {
+                  const next = [...cur];
+                  next[i] = e.target.files?.[0] ?? null;
+                  return next;
+                })
+              }
+            />
+            {files.length > 1 && (
+              <button
+                type="button"
+                className="text-red-600 px-2 py-1 rounded focus:outline focus:outline-2 focus:outline-accent"
+                onClick={() =>
+                  setFiles((cur) => cur.filter((_, idx) => idx !== i))
+                }
+              >
+                Remove
+              </button>
+            )}
+          </div>
         ))}
         {files.length < 20 && (
           <button

--- a/src/pages/EditAssistantPage.tsx
+++ b/src/pages/EditAssistantPage.tsx
@@ -240,18 +240,30 @@ export default function EditAssistantPage() {
           </div>
         )}
         {newFiles.map((_, i) => (
-          <input
-            key={i}
-            className="border p-2 w-full rounded-lg focus:outline focus:outline-2 focus:outline-accent"
-            type="file"
-            onChange={(e) =>
-              setNewFiles((cur) => {
-                const next = [...cur];
-                next[i] = e.target.files?.[0] ?? null;
-                return next;
-              })
-            }
-          />
+          <div key={i} className="flex items-center space-x-2">
+            <input
+              className="border p-2 flex-1 rounded-lg focus:outline focus:outline-2 focus:outline-accent"
+              type="file"
+              onChange={(e) =>
+                setNewFiles((cur) => {
+                  const next = [...cur];
+                  next[i] = e.target.files?.[0] ?? null;
+                  return next;
+                })
+              }
+            />
+            {newFiles.length > 1 && (
+              <button
+                type="button"
+                className="text-red-600 px-2 py-1 rounded focus:outline focus:outline-2 focus:outline-accent"
+                onClick={() =>
+                  setNewFiles((cur) => cur.filter((_, idx) => idx !== i))
+                }
+              >
+                Remove
+              </button>
+            )}
+          </div>
         ))}
         {newFiles.length < 20 && (
           <button


### PR DESCRIPTION
## Summary
- allow users to remove file inputs when creating an assistant
- allow users to remove file inputs when editing an assistant

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*