### PR TITLE
Fix jwt-decode import error

### DIFF
--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import jwtDecode from 'jwt-decode';
+import { jwtDecode } from 'jwt-decode';
 
 const api = axios.create({ baseURL: import.meta.env.VITE_API_BASE_URL });
 


### PR DESCRIPTION
## Summary
- import `jwtDecode` as a named export

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*