### PR TITLE
Add react-hook-form wrapper and sample department page

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "jwt-decode": "^4.0.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "6.23.0"
+    "react-router-dom": "6.23.0",
+    "react-hook-form": "^7.50.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/lib/form.js
+++ b/src/lib/form.js
@@ -1,0 +1,5 @@
+import { useForm as useRHFForm } from 'react-hook-form';
+
+export const useForm = (options = {}) => useRHFForm({ criteriaMode: 'all', ...options });
+
+export * from 'react-hook-form';

--- a/src/pages/AdminDepartments.jsx
+++ b/src/pages/AdminDepartments.jsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import api from '../api/axios';
+import { useForm } from '../lib/form';
+
+export default function AdminDepartments() {
+  const [error, setError] = useState(null);
+  const { register, handleSubmit, reset, formState: { errors } } = useForm({
+    defaultValues: { name: '' },
+  });
+
+  const onSubmit = async ({ name }) => {
+    try {
+      await api.post('/api/departments/', { name });
+      reset();
+      setError(null);
+    } catch (err) {
+      const msg = err?.response?.data?.name?.[0] || 'Error';
+      setError(msg);
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-2">
+      <h1 className="text-xl font-bold">Departments</h1>
+      <form onSubmit={handleSubmit(onSubmit)} className="flex space-x-2">
+        <input
+          className="border p-2 rounded"
+          {...register('name', { required: 'Name is required' })}
+        />
+        <button className="bg-blue-600 text-white px-3 py-1 rounded" type="submit">
+          Add
+        </button>
+      </form>
+      {errors.name && <p className="text-red-600">{errors.name.message}</p>}
+      {error && <p className="text-red-600">{error}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- install `react-hook-form`
- add custom `useForm` wrapper in `src/lib/form.js`
- create `AdminDepartments.jsx` using the wrapper for its add form

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*