### PR TITLE
Downgrade to React 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,15 @@
       "name": "assistant-frontend",
       "version": "0.0.0",
       "dependencies": {
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0",
-        "react-router-dom": "^7.6.1"
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^7.6.1",
+        "classnames": "^2.5.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
-        "@types/react": "^19.1.2",
-        "@types/react-dom": "^19.1.2",
+        "@types/react": "^18.2.40",
+        "@types/react-dom": "^18.2.17",
         "@vitejs/plugin-react": "^4.4.1",
         "autoprefixer": "^10.4.21",
         "eslint": "^9.25.0",
@@ -1352,21 +1353,21 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "19.1.5",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.5.tgz",
-      "integrity": "sha512-piErsCVVbpMMT2r7wbawdZsq4xMvIAhQuac2gedQHysu1TZYEigE6pnFfgZT+/jQnrRuF5r+SHzuehFjfRjr4g==",
+      "version": "18.2.40",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.40.tgz",
+      "integrity": "sha512-q+ZFsapMI2vlA38nSxrdbidKdvUSsfx8bVsgcuyo6edSxnl2xe50Tzw9uQWGWpZJYG1ChcxrFAxo0xO+ogzAmA==",
       "dev": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.1.5",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.5.tgz",
-      "integrity": "sha512-CMCjrWucUBZvohgZxkjd6S9h0nZxXjzus6yDfUb+xLxYM7VvjKNH1tQrE9GWLql1XoOP4/Ds3bwFqShHUYraGg==",
+      "version": "18.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.17.tgz",
+      "integrity": "sha512-9kxbT+kEcL50DJBSSTXobHxPPH/FkOFjvFsRQAt2bQVWwtIg9Y9ycYzaO+VxDRCcIh0b07XHtcwPa5wPLXr0lQ==",
       "dev": true,
       "peerDependencies": {
-        "@types/react": "^19.0.0"
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1863,6 +1864,11 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-zGcwKMdxDKbk9wjFtDfiAUFtaCuAlM3gS+a3Pl6xNcNehJIKBNB1LsYpe3K8QxSNaben7TBPhYu95LjGH0qhCQ=="
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -3246,22 +3252,22 @@
       ]
     },
     "node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-6pRCejF0OSAmUJ+zsOZvlsgCvtPOtHOcYgmK5kEz7dhIK0Qz5yJ10qmHjlkrmysZ7fUXuTjs4sS6M2dPefXqBQ==",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
-      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-bI2EzoGCGNMK2JcyHEwvUogI+44DyL5yHtsVx64X2hiWvXZ9cu3M/b3aX2B9fFJAzHzVXKyZj7pTz13PeIrACQ==",
       "dependencies": {
-        "scheduler": "^0.26.0"
+        "scheduler": "^0.23.0"
       },
       "peerDependencies": {
-        "react": "^19.1.0"
+        "react": "^18.2.0"
       }
     },
     "node_modules/react-refresh": {
@@ -3432,9 +3438,9 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-Yq+vQBy06SnVAk0nnBYnCTsRmR271GGBqBPdZiZsaAJ+lZeX7IuAv89xDSHLVQQDBlnJrped1IovnHgwlHGObA=="
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -13,17 +13,17 @@
   "dependencies": {
     "axios": "^1.6.0",
     "jwt-decode": "^4.0.0",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-router-dom": "6.23.0",
     "react-hook-form": "^7.50.0",
     "@tanstack/react-query": "^5.52.0",
-    "shadcn-ui-classnames": "^1.0.0"
+    "classnames": "^2.5.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
-    "@types/react": "^19.1.2",
-    "@types/react-dom": "^19.1.2",
+    "@types/react": "^18.2.40",
+    "@types/react-dom": "^18.2.17",
     "@vitejs/plugin-react": "^4.4.1",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.25.0",


### PR DESCRIPTION
## Summary
- replace invalid `shadcn-ui-classnames` with `classnames`
- pin React and ReactDOM to version 18
- align type packages to React 18
- update lockfile

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*