### PR TITLE
Fix React Query v5 usage

### DIFF
--- a/src/hooks/useDepartments.js
+++ b/src/hooks/useDepartments.js
@@ -2,8 +2,11 @@ import { useQuery } from '@tanstack/react-query';
 import api from '../api/axios';
 
 export function useDepartments() {
-  return useQuery(['departments'], async () => {
-    const { data } = await api.get('/api/departments/');
-    return data;
+  return useQuery({
+    queryKey: ['departments'],
+    queryFn: async () => {
+      const { data } = await api.get('/api/departments/');
+      return data;
+    },
   });
 }

--- a/src/hooks/useUsers.js
+++ b/src/hooks/useUsers.js
@@ -2,37 +2,45 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api from '../api/axios';
 
 export function useUsers() {
-  return useQuery(['users'], async () => {
-    const { data } = await api.get('/api/users/');
-    return data;
+  return useQuery({
+    queryKey: ['users'],
+    queryFn: async () => {
+      const { data } = await api.get('/api/users/');
+      return data;
+    },
   });
 }
 
 export function useCreateUser() {
   const qc = useQueryClient();
-  return useMutation((payload) => api.post('/api/users/', payload), {
-    onSuccess: () => qc.invalidateQueries(['users']),
+  return useMutation({
+    mutationFn: (payload) => api.post('/api/users/', payload),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['users'] }),
   });
 }
 
 export function useUpdateUser() {
   const qc = useQueryClient();
-  return useMutation(({ id, data }) => api.patch(`/api/users/${id}/`, data), {
-    onSuccess: () => qc.invalidateQueries(['users']),
+  return useMutation({
+    mutationFn: ({ id, data }) => api.patch(`/api/users/${id}/`, data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['users'] }),
   });
 }
 
 export function useToggleActive() {
   const qc = useQueryClient();
-  return useMutation(
-    ({ id, active }) => api.patch(`/api/users/${id}/`, { is_active: active }),
-    { onSuccess: () => qc.invalidateQueries(['users']) },
-  );
+  return useMutation({
+    mutationFn: ({ id, active }) =>
+      api.patch(`/api/users/${id}/`, { is_active: active }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['users'] }),
+  });
 }
 
 export function useResetPassword() {
   const qc = useQueryClient();
-  return useMutation(({ id, body = {} }) => api.post(`/api/users/${id}/reset_password/`, body), {
-    onSuccess: () => qc.invalidateQueries(['users']),
+  return useMutation({
+    mutationFn: ({ id, body = {} }) =>
+      api.post(`/api/users/${id}/reset_password/`, body),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['users'] }),
   });
 }


### PR DESCRIPTION
## Summary
- update hooks to use object syntax for React Query v5

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*