### PR TITLE
Add Home link to header

### DIFF
--- a/src/routes/ProtectedRoute.jsx
+++ b/src/routes/ProtectedRoute.jsx
@@ -15,6 +15,9 @@ export default function ProtectedRoute() {
       <header className="p-2 border-b flex justify-between items-center">
         <span className="text-sm text-gray-700">Logged in as {user.username}</span>
         <div className="flex gap-4 items-center">
+          <Link className="text-accentBlue underline" to="/assistants">
+            Home
+          </Link>
           {user.is_staff && (
             <Link className="text-accentBlue underline" to="/admin/users">
               Users


### PR DESCRIPTION
## Summary
- add a Home link in the main header so users can easily navigate back to the assistants list

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*