### PR TITLE
Implement F-004 frontend permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,4 +84,14 @@ Admins can manage user accounts at `/admin/users` when logged in. The screen lis
 
 ![Users](docs/users.gif)
 
+## Assistant permissions
+
+Assistants you can access will show a colored badge indicating your level:
+
+![Permissions](docs/permissions.png)
+
+* **Owner** – you created the assistant and can fully manage it.
+* **Edit** – you may update settings and files.
+* **Use** – read-only access for chatting.
+
 

--- a/src/__tests__/assistants.test.jsx
+++ b/src/__tests__/assistants.test.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import App from '../App';
+import { AuthProvider } from '../context/AuthContext';
+import api from '../api/axios';
+
+jest.mock('../api/axios');
+
+function renderWithProviders(route = '/assistants') {
+  api.post.mockResolvedValue({});
+  api.get.mockResolvedValue({ data: { username: 'user' } });
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </MemoryRouter>,
+  );
+}
+
+test('assistants list shows items from API', async () => {
+  api.get
+    .mockResolvedValueOnce({ data: [{ id: '1', name: 'A', description: '', model: 'gpt-4o', permission: 'edit', owner: false }] })
+    .mockResolvedValue({ data: { username: 'u' } });
+  renderWithProviders('/assistants');
+  await waitFor(() => screen.getByText('A'));
+  expect(screen.getByText('A')).toBeInTheDocument();
+});
+
+test('use permission shows Use badge', async () => {
+  api.get
+    .mockResolvedValueOnce({ data: [{ id: '1', name: 'A', description: '', model: 'gpt-4o', permission: 'use', owner: false }] })
+    .mockResolvedValue({ data: { username: 'u' } });
+  renderWithProviders('/assistants');
+  await waitFor(() => screen.getByText('A'));
+  expect(screen.getByText('Use')).toBeInTheDocument();
+});

--- a/src/components/AssistantCard.tsx
+++ b/src/components/AssistantCard.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import PermissionBadge from './PermissionBadge';
+import type { Assistant } from '../pages/HomePage';
+
+interface Props {
+  assistant: Assistant & { permission?: 'use' | 'edit'; owner?: boolean };
+  onDelete?: (id: string) => void;
+}
+
+export default function AssistantCard({ assistant, onDelete }: Props) {
+  const navigate = useNavigate();
+  const canEdit = assistant.owner || assistant.permission === 'edit';
+  return (
+    <div
+      className="border p-4 rounded-lg cursor-pointer hover:bg-gray-50 flex items-start"
+      onClick={() => navigate(`/assistants/${assistant.id}`)}
+    >
+      <div className="flex-grow">
+        <h2 className="text-lg font-semibold">{assistant.name}</h2>
+        <p className="text-sm text-gray-700 whitespace-pre-line">
+          {assistant.description}
+        </p>
+        <p className="text-sm text-gray-500">Model: {assistant.model}</p>
+      </div>
+      <div className="flex flex-col items-end ml-2 gap-1">
+        <PermissionBadge owner={assistant.owner} permission={assistant.permission} />
+        {canEdit && (
+          <div className="flex gap-1">
+            <button
+              aria-label="Edit"
+              title="Edit"
+              className="text-gray-700 px-2 py-1 rounded focus:outline focus:outline-2 focus:outline-accent"
+              onClick={(e) => {
+                e.stopPropagation();
+                navigate(`/assistants/${assistant.id}/edit`);
+              }}
+            >
+              ✏️
+            </button>
+            <button
+              aria-label="Delete"
+              title="Delete"
+              className="text-red-600 px-2 py-1 rounded focus:outline focus:outline-2 focus:outline-accent"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete && onDelete(assistant.id);
+              }}
+            >
+              🗑
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/PermissionBadge.tsx
+++ b/src/components/PermissionBadge.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import classNames from 'classnames';
+
+interface Props {
+  owner?: boolean;
+  permission?: 'use' | 'edit';
+}
+
+export default function PermissionBadge({ owner, permission }: Props) {
+  let label = 'Use';
+  let color = 'bg-gray-500';
+
+  if (owner) {
+    label = 'Owner';
+    color = 'bg-purple-600';
+  } else if (permission === 'edit') {
+    label = 'Edit';
+    color = 'bg-green-600';
+  }
+
+  return (
+    <span className={classNames('text-xs text-white px-2 py-0.5 rounded', color)}>
+      {label}
+    </span>
+  );
+}

--- a/src/hooks/useAssistant.js
+++ b/src/hooks/useAssistant.js
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '../api/axios';
+
+export class NotAllowedError extends Error {}
+
+export function useAssistant(id) {
+  return useQuery({
+    queryKey: ['assistant', id],
+    queryFn: async () => {
+      try {
+        const { data } = await api.get(`/api/assistants/${id}/`);
+        return data;
+      } catch (err) {
+        if (err.response?.status === 403 || err.response?.status === 404) {
+          throw new NotAllowedError('Not allowed');
+        }
+        throw err;
+      }
+    },
+    retry: false,
+  });
+}

--- a/src/hooks/useAssistants.js
+++ b/src/hooks/useAssistants.js
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '../api/axios';
+
+export function useAssistants() {
+  return useQuery({
+    queryKey: ['assistants'],
+    queryFn: async () => {
+      const { data } = await api.get('/api/assistants/');
+      return data;
+    },
+  });
+}

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import api from '../api/axios';
 import type { Assistant } from './HomePage';
+import { useAssistant, NotAllowedError } from '../hooks/useAssistant';
 import Markdown from '../components/Markdown';
 
 interface Message {
@@ -13,7 +14,7 @@ interface Message {
 export default function ChatPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const [assistant, setAssistant] = useState<Assistant | null>(null);
+  const { data: assistant, error } = useAssistant(id || '');
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
   const [status, setStatus] = useState<string | null>(null);
@@ -21,14 +22,12 @@ export default function ChatPage() {
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
 
-  const fetchAssistant = async () => {
-    try {
-      const { data } = await api.get(`/api/assistants/${id}/`);
-      setAssistant(data);
-    } catch {
-      // ignore errors
+  useEffect(() => {
+    if (error instanceof NotAllowedError) {
+      alert('Assistant not available');
+      navigate('/assistants');
     }
-  };
+  }, [error, navigate]);
 
   const fetchMessages = async () => {
     try {
@@ -43,7 +42,6 @@ export default function ChatPage() {
   };
 
   useEffect(() => {
-    void fetchAssistant();
     void fetchMessages();
   }, [id]);
 

--- a/src/pages/EditAssistantPage.tsx
+++ b/src/pages/EditAssistantPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import api from '../api/axios';
+import { useAssistant, NotAllowedError } from '../hooks/useAssistant';
 
 const MODEL_OPTIONS = ['gpt-4', 'gpt-4o', 'o3-mini'];
 
@@ -19,6 +20,15 @@ export default function EditAssistantPage() {
   const [vectorFiles, setVectorFiles] = useState<{ id: string; filename: string }[]>([]);
   const [vectorStatus, setVectorStatus] = useState<string | null>(null);
   const navigate = useNavigate();
+  const { data: assistant, error } = useAssistant(id || '');
+  const readonly = !!assistant && assistant.permission === 'use' && !assistant.owner;
+
+  useEffect(() => {
+    if (error instanceof NotAllowedError) {
+      alert('Assistant not available');
+      navigate('/assistants');
+    }
+  }, [error, navigate]);
 
   const deleteVectorFile = async (fileId: string) => {
     if (!id) return;
@@ -58,7 +68,24 @@ export default function EditAssistantPage() {
   };
 
   useEffect(() => {
-    void fetchAssistant();
+    if (assistant) {
+      setName(assistant.name || '');
+      setDescription(assistant.description || '');
+      setInstructions(assistant.instructions || '');
+      setModel(assistant.model || '');
+      if (Array.isArray(assistant.tools)) {
+        setFileSearch(
+          assistant.tools.some((t: any) =>
+            typeof t === 'string'
+              ? t === 'file_search'
+              : t && t.type === 'file_search',
+          ),
+        );
+      }
+      if (Array.isArray(assistant.files)) {
+        setExistingFiles(assistant.files);
+      }
+    }
     const fetchVectorFiles = async () => {
       if (!id) return;
       try {
@@ -87,7 +114,7 @@ export default function EditAssistantPage() {
     };
 
     void fetchVectorFiles();
-  }, [id]);
+  }, [assistant, id]);
 
   const updateAssistant = async () => {
     if (waiting) {
@@ -132,6 +159,9 @@ export default function EditAssistantPage() {
         Back
       </button>
       <h1 className="text-xl font-bold">Edit Assistant</h1>
+      {readonly && (
+        <div className="bg-blue-100 text-blue-800 p-2 rounded">Read-only access</div>
+      )}
       <div className="space-y-2">
         <div className="space-y-1">
           <span>Name</span>
@@ -141,6 +171,7 @@ export default function EditAssistantPage() {
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="Name"
+            disabled={readonly}
           />
         </div>
         <div className="space-y-1">
@@ -150,6 +181,7 @@ export default function EditAssistantPage() {
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             placeholder="Description"
+            disabled={readonly}
           />
         </div>
         <div className="space-y-1">
@@ -159,6 +191,7 @@ export default function EditAssistantPage() {
             value={instructions}
             onChange={(e) => setInstructions(e.target.value)}
             placeholder="Instructions"
+            disabled={readonly}
           />
         </div>
         <div className="space-y-1">
@@ -167,6 +200,7 @@ export default function EditAssistantPage() {
             className="border p-2 w-full rounded-lg focus:outline focus:outline-2 focus:outline-accent"
             value={model}
             onChange={(e) => setModel(e.target.value)}
+            disabled={readonly}
           >
             <option value="">Select Model</option>
             {MODEL_OPTIONS.map((m) => (
@@ -181,6 +215,7 @@ export default function EditAssistantPage() {
             type="checkbox"
             checked={fileSearch}
             onChange={(e) => setFileSearch(e.target.checked)}
+            disabled={readonly}
           />
           <span>Enable file search</span>
         </div>
@@ -260,7 +295,7 @@ export default function EditAssistantPage() {
             Remove
           </div>
         ))}
-        {newFiles.length < 20 && (
+        {newFiles.length < 20 && !readonly && (
           <button
             type="button"
             className="bg-gray-200 text-gray-700 px-2 py-1 rounded"
@@ -276,7 +311,7 @@ export default function EditAssistantPage() {
         )}
         <button
           className="bg-accent text-white px-4 py-2 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
-          disabled={waiting}
+          disabled={waiting || readonly}
           onClick={updateAssistant}
         >
           Update


### PR DESCRIPTION
## Notes
- Jest could not run in the container because `jest` is missing in the runtime image.

## Summary
- add hooks for assistants
- permission badges and cards on dashboard
- readonly handling on edit page
- update chat page to use assistant hook
- document assistant permission badges

## Testing
- `npm test` *(fails: jest not found)*