### PR TITLE
Fix share hooks to accept options

### DIFF
--- a/src/__tests__/share.test.jsx
+++ b/src/__tests__/share.test.jsx
@@ -40,6 +40,17 @@ test('non-owner hides Share button', async () => {
   expect(screen.queryByText('Share')).toBeNull();
 });
 
+test('non-owner does not fetch share data', async () => {
+  renderChat(false);
+  await waitFor(() => screen.getByText(/chat with/i));
+  expect(api.get).not.toHaveBeenCalledWith(
+    expect.stringContaining('/shares/users/'),
+  );
+  expect(api.get).not.toHaveBeenCalledWith(
+    expect.stringContaining('/shares/departments/'),
+  );
+});
+
 test('modal lists current shares', async () => {
   api.get.mockImplementation((url) => {
     if (url === '/api/assistants/1/') {

--- a/src/hooks/useAssistantShares.js
+++ b/src/hooks/useAssistantShares.js
@@ -1,23 +1,25 @@
 import { useQuery } from '@tanstack/react-query';
 import api from '../api/axios';
 
-export function useAssistantUserShares(aid) {
+export function useAssistantUserShares(aid, options = {}) {
   return useQuery({
     queryKey: ['assistant', 'shares', aid, 'users'],
     queryFn: async () => {
       const { data } = await api.get(`/api/assistants/${aid}/shares/users/`);
       return data;
     },
+    ...options,
   });
 }
 
-export function useAssistantDeptShares(aid) {
+export function useAssistantDeptShares(aid, options = {}) {
   return useQuery({
     queryKey: ['assistant', 'shares', aid, 'depts'],
     queryFn: async () => {
       const { data } = await api.get(`/api/assistants/${aid}/shares/departments/`);
       return data;
     },
+    ...options,
   });
 }
 


### PR DESCRIPTION
## Summary
- allow passing options to `useAssistantUserShares` and `useAssistantDeptShares`
- update tests to ensure share API isn't called when user isn't owner

## Testing
- `npm test --silent` *(fails: jest not found)*