### PR TITLE
Fix chat user messages visibility

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,6 +22,7 @@ export default {
                 neutral6: 'var(--color-neutral-6)',
                 neutral7: 'var(--color-neutral-7)',
                 neutral8: 'var(--color-neutral-8)',
+                "on-primary": 'var(--text-on-primary)',
             },
             spacing: {
                 1: 'var(--sp-1)',


### PR DESCRIPTION
## Summary
- add `on-primary` color to Tailwind theme so `text-on-primary` works again

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*