### PR TITLE
Fix icons missing on assistant cards

### DIFF
--- a/docs/icons.md
+++ b/docs/icons.md
@@ -1,6 +1,7 @@
 # Icons
 
-This project uses [lucide-react](https://github.com/lucide-icons/lucide) for all UI icons. Import the `Icon` wrapper from `src/components/ui/Icon` and pass the icon name.
+This project uses [lucide-react](https://github.com/lucide-icons/lucide) for all UI icons. Only the icons actually used in the app are imported to keep the bundle small.
+Import the `Icon` wrapper from `src/components/ui/Icon` and pass the icon name.
 
 ```tsx
 import Icon from '../components/ui/Icon';

--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
-import * as Icons from 'lucide-react';
+import { Pencil, Trash2, X } from 'lucide-react';
 import classNames from 'classnames';
 
-export type LucideIconName = keyof typeof Icons;
+// Only import icons used in the application. Add new ones here as needed.
+const icons = { Pencil, Trash2, X };
+
+export type IconName = keyof typeof icons;
 
 const sizeMap = { sm: 16, md: 20, lg: 24 } as const;
 
 export interface IconProps extends React.SVGProps<SVGSVGElement> {
-  name: LucideIconName;
+  name: IconName;
   size?: keyof typeof sizeMap;
   colorToken?: string;
   className?: string;
@@ -20,7 +23,7 @@ export default function Icon({
   colorToken,
   ...rest
 }: IconProps) {
-  const Lucide = Icons[name] as React.FC<React.SVGProps<SVGSVGElement>>;
+  const Lucide = icons[name];
   return (
     <Lucide
       stroke="currentColor"

--- a/src/stories/Icon.stories.tsx
+++ b/src/stories/Icon.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import * as Icons from 'lucide-react';
+import { Pencil, Trash2, X } from 'lucide-react';
+const icons = { Pencil, Trash2, X } as const;
 import Icon from '../components/ui/Icon';
 
 export default {
@@ -7,7 +8,7 @@ export default {
 };
 
 export const All = () => {
-  const names = Object.keys(Icons).slice(0, 120) as Array<keyof typeof Icons>;
+  const names = Object.keys(icons) as Array<keyof typeof icons>;
   return (
     <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, 80px)', gap: 16 }}>
       {names.map((name) => (


### PR DESCRIPTION
## Summary
- fix Icon component to import only needed icons
- update docs to clarify how icons are imported
- update story to match new Icon mapping

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*