### PR TITLE
Fix accent color so buttons render

### DIFF
--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -4,6 +4,7 @@
   --color-secondary: #6b7280;
   --color-background: #ffffff;
   --color-surface: #f9fafb;
+  --color-accent: #0a84ff;
   --color-neutral-1: #ffffff;
   --color-neutral-2: #f3f4f6;
   --color-neutral-3: #e5e7eb;

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -14,6 +14,7 @@ export const TOKENS = {
   'color-success': 'var(--color-success)',
   'color-warning': 'var(--color-warning)',
   'color-danger': 'var(--color-danger)',
+  'color-accent': 'var(--color-accent)',
   'text-primary': 'var(--text-primary)',
   'text-secondary': 'var(--text-secondary)',
   'text-on-primary': 'var(--text-on-primary)',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,7 @@ export default {
                 success: 'var(--color-success)',
                 warning: 'var(--color-warning)',
                 danger: 'var(--color-danger)',
+                accent: 'var(--color-accent)',
                 neutral1: 'var(--color-neutral-1)',
                 neutral2: 'var(--color-neutral-2)',
                 neutral3: 'var(--color-neutral-3)',


### PR DESCRIPTION
## Summary
- define `--color-accent` token
- expose accent color in Tailwind
- export accent token for JS

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*