### PR TITLE
Increase textarea size on assistant forms

### DIFF
--- a/src/pages/CreateAssistantPage.tsx
+++ b/src/pages/CreateAssistantPage.tsx
@@ -71,6 +71,7 @@ export default function CreateAssistantPage() {
         <div className="space-y-1">
           <span>Description</span>
           <TextArea
+            rows={4}
             className="w-full"
             value={description}
             onChange={(e) => setDescription(e.target.value)}
@@ -80,6 +81,7 @@ export default function CreateAssistantPage() {
         <div className="space-y-1">
           <span>Instructions</span>
           <TextArea
+            rows={4}
             className="w-full"
             value={instructions}
             onChange={(e) => setInstructions(e.target.value)}

--- a/src/pages/EditAssistantPage.tsx
+++ b/src/pages/EditAssistantPage.tsx
@@ -154,6 +154,7 @@ export default function EditAssistantPage() {
         <div className="space-y-1">
           <span>Description</span>
           <textarea
+            rows={4}
             className="border p-2 w-full rounded-lg focus:outline focus:outline-2 focus:outline-accent"
             value={description}
             onChange={(e) => setDescription(e.target.value)}
@@ -164,6 +165,7 @@ export default function EditAssistantPage() {
         <div className="space-y-1">
           <span>Instructions</span>
           <textarea
+            rows={4}
             className="border p-2 w-full rounded-lg focus:outline focus:outline-2 focus:outline-accent"
             value={instructions}
             onChange={(e) => setInstructions(e.target.value)}


### PR DESCRIPTION
## Summary
- expand description and instructions fields to 4 rows on create/edit assistant forms

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*