### PR TITLE
Add auto-resizing instructions textarea

### DIFF
--- a/src/components/ui/TextArea.tsx
+++ b/src/components/ui/TextArea.tsx
@@ -1,15 +1,41 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import classNames from 'classnames';
 
-export interface TextAreaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export interface TextAreaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  autoResize?: boolean;
+}
 
-export default function TextArea({ className, ...rest }: TextAreaProps) {
+export default function TextArea({ className, autoResize, onInput, ...rest }: TextAreaProps) {
+  const ref = useRef<HTMLTextAreaElement>(null);
+
+  const adjustHeight = () => {
+    const el = ref.current;
+    if (el) {
+      el.style.height = 'auto';
+      el.style.height = `${el.scrollHeight}px`;
+    }
+  };
+
+  useEffect(() => {
+    if (autoResize) {
+      adjustHeight();
+    }
+  }, [rest.value, autoResize]);
+
   return (
     <textarea
+      ref={ref}
       className={classNames(
         'border border-neutral4 rounded-sm px-3 py-2 focus:outline focus:outline-[3px] focus:outline-offset-2 focus:outline-primary disabled:opacity-50 disabled:cursor-not-allowed aria-invalid:border-danger',
         className,
       )}
+      onInput={(e) => {
+        if (autoResize) {
+          adjustHeight();
+        }
+        onInput?.(e);
+      }}
       {...rest}
     />
   );

--- a/src/pages/CreateAssistantPage.tsx
+++ b/src/pages/CreateAssistantPage.tsx
@@ -86,6 +86,7 @@ export default function CreateAssistantPage() {
             value={instructions}
             onChange={(e) => setInstructions(e.target.value)}
             placeholder="Instructions"
+            autoResize
           />
         </div>
         <div className="space-y-1">

--- a/src/pages/EditAssistantPage.tsx
+++ b/src/pages/EditAssistantPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import api from '../api/axios';
 import { useAssistant, NotAllowedError } from '../hooks/useAssistant';
+import TextArea from '../components/ui/TextArea';
 
 const MODEL_OPTIONS = ['gpt-4', 'gpt-4o', 'o3-mini'];
 
@@ -164,13 +165,14 @@ export default function EditAssistantPage() {
         </div>
         <div className="space-y-1">
           <span>Instructions</span>
-          <textarea
+          <TextArea
             rows={4}
-            className="border p-2 w-full rounded-lg focus:outline focus:outline-2 focus:outline-accent"
+            className="w-full"
             value={instructions}
             onChange={(e) => setInstructions(e.target.value)}
             placeholder="Instructions"
             disabled={readonly}
+            autoResize
           />
         </div>
         <div className="space-y-1">


### PR DESCRIPTION
## Summary
- allow `TextArea` component to grow with content using new `autoResize` prop
- use the new prop for assistant instruction fields

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*