### PR TITLE
fix vector store 404 handling

### DIFF
--- a/src/__tests__/editAssistantVector.test.jsx
+++ b/src/__tests__/editAssistantVector.test.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import App from '../App';
+import { AuthProvider } from '../context/AuthContext';
+import api from '../api/axios';
+
+jest.mock('../api/axios');
+
+function renderEdit(assistantData, vectorResponse) {
+  api.post.mockResolvedValue({});
+  api.get.mockImplementation((url) => {
+    if (url === '/api/assistants/1/') {
+      return Promise.resolve({ data: assistantData });
+    }
+    if (url === '/api/assistants/1/vector-store/files/') {
+      if (vectorResponse === '404') {
+        return Promise.reject({ response: { status: 404, data: 'missing' } });
+      }
+      return Promise.resolve({ data: vectorResponse });
+    }
+    return Promise.resolve({ data: { username: 'u' } });
+  });
+
+  return render(
+    <MemoryRouter initialEntries={["/assistants/1/edit"]}>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </MemoryRouter>,
+  );
+}
+
+test('edit page loads without vector store request when file_search disabled', async () => {
+  renderEdit({ id: '1', name: 'A', tools: [], files: [], model: 'gpt-4', owner: true }, []);
+  await waitFor(() => screen.getByText(/edit assistant/i));
+  expect(api.get).not.toHaveBeenCalledWith(
+    '/api/assistants/1/vector-store/files/',
+  );
+});
+
+test('shows message when vector store missing', async () => {
+  renderEdit({ id: '1', name: 'A', tools: ['file_search'], files: [], model: 'gpt-4', owner: true }, '404');
+  await waitFor(() => screen.getByText('No vector store for this assistant.'));
+});

--- a/src/pages/EditAssistantPage.tsx
+++ b/src/pages/EditAssistantPage.tsx
@@ -46,24 +46,6 @@ export default function EditAssistantPage() {
 
 
   useEffect(() => {
-    if (assistant) {
-      setName(assistant.name || '');
-      setDescription(assistant.description || '');
-      setInstructions(assistant.instructions || '');
-      setModel(assistant.model || '');
-      if (Array.isArray(assistant.tools)) {
-        setFileSearch(
-          assistant.tools.some((t: any) =>
-            typeof t === 'string'
-              ? t === 'file_search'
-              : t && t.type === 'file_search',
-          ),
-        );
-      }
-      if (Array.isArray(assistant.files)) {
-        setExistingFiles(assistant.files);
-      }
-    }
     const fetchVectorFiles = async () => {
       if (!id) return;
       try {
@@ -84,14 +66,39 @@ export default function EditAssistantPage() {
           setVectorFiles(items);
       } catch (err: any) {
         if (err.response?.status === 404) {
+          setVectorFiles([]);
           setVectorStatus(err.response.data || 'No vector store for this assistant.');
         } else {
           setVectorStatus(`Error: ${err.message}`);
         }
       }
     };
+    if (assistant) {
+      setName(assistant.name || '');
+      setDescription(assistant.description || '');
+      setInstructions(assistant.instructions || '');
+      setModel(assistant.model || '');
 
-    void fetchVectorFiles();
+      const hasFileSearch = Array.isArray(assistant.tools)
+        ? assistant.tools.some((t: any) =>
+            typeof t === 'string'
+              ? t === 'file_search'
+              : t && t.type === 'file_search',
+          )
+        : false;
+      setFileSearch(hasFileSearch);
+
+      if (Array.isArray(assistant.files)) {
+        setExistingFiles(assistant.files);
+      }
+
+      if (hasFileSearch) {
+        void fetchVectorFiles();
+      } else {
+        setVectorFiles([]);
+        setVectorStatus('No vector store for this assistant.');
+      }
+    }
   }, [assistant, id]);
 
   const updateAssistant = async () => {

--- a/src/pages/VectorStoreFilesPage.tsx
+++ b/src/pages/VectorStoreFilesPage.tsx
@@ -36,6 +36,7 @@ export default function VectorStoreFilesPage() {
         setFiles(items);
       } catch (err: any) {
         if (err.response?.status === 404) {
+          setFiles([]);
           setStatus(err.response.data || 'No vector store for this assistant.');
         } else {
           setStatus(`Error: ${err.message}`);


### PR DESCRIPTION
## Summary
- handle missing vector store gracefully in `EditAssistantPage`
- clear files and show message when vector store not found in `VectorStoreFilesPage`
- add regression test for editing assistants without a vector store

## Testing
- `npm test --silent` *(fails: jest not found)*